### PR TITLE
Bump lib versions

### DIFF
--- a/.github/workflows/ex.yml
+++ b/.github/workflows/ex.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Check types with mypy
       run: |
-        mypy --show-traceback --check-untyped-defs .
+        mypy --show-traceback --check-untyped-defs --local-partial-types .
 
     - name: Lint with ruff
       run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-mypy~=1.11.2
+mypy~=1.12.0
 mypy-extensions
 types-PyYAML 
 types-Pygments 
 types-colorama 
 types-setuptools
-ruff~=0.6.9
+ruff~=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ tomli~=2.0.2
 tomli_w~=1.1.0
 termcolor~=2.5.0
 pydantic~=2.9.2
+pydantic-settings~=2.6.0
 pytest~=8.3.3
-pydantic-settings~=2.5.2
 coverage~=7.6.3
-# coverage-badge~=1.1.2
 pytest-cov~=5.0.0
+
 # The next version (0.9.3) I tried had broken support for asctime in the formatter
 # IDK about 0.9.2
 # OK, new comment here, picologging 0.9.1 and 0.9.2 are causing segfaults when exiting the program. Ugh.

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,7 +15,7 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env")
 
-    _instance = None
+    _instance: Settings | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -33,3 +35,4 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+assert settings is not None


### PR DESCRIPTION
New versions of ruff, mypy, and pydantic-settings have been released. Most notable is mypy, with it's better support of newer, Python 3.12, typing syntax.